### PR TITLE
fix(streaming): resolve panics and reliability issues in v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maormil-rabbitmq-datasource",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Rabbitmq streaming datasource plugin",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/plugin/framer.go
+++ b/pkg/plugin/framer.go
@@ -74,7 +74,15 @@ func (df *Framer) Key() string {
 
 func (df *Framer) AddNil() {
 	if idx, ok := df.FieldMap[df.Key()]; ok {
-		df.Fields[idx].Set(0, nil)
+		// Only call Append(nil) for nullable field types. Non-nullable types such as
+		// FieldTypeJSON panic on Append(nil) because the SDK does an internal type
+		// assertion to json.RawMessage which fails for an untyped nil interface value
+		// ("interface conversion: interface {} is nil, not json.RawMessage").
+		// For non-nullable fields we skip the append and let ExtendFields pad with
+		// the type's zero value instead.
+		if df.Fields[idx].Type().Nullable() {
+			df.Fields[idx].Append(nil)
+		}
 		return
 	}
 	log.DefaultLogger.Debug("Nil value for unknown field", "key", df.Key())
@@ -83,8 +91,10 @@ func (df *Framer) AddNil() {
 func (df *Framer) AddValue(fieldType data.FieldType, v interface{}) {
 	if idx, ok := df.FieldMap[df.Key()]; ok {
 		if df.Fields[idx].Type() != fieldType {
-			log.DefaultLogger.Debug("Field type mismatch", "key", df.Key(), "existing", df.Fields[idx], "new", fieldType)
-			return
+			log.DefaultLogger.Debug("Field type changed, replacing field", "key", df.Key(), "old", df.Fields[idx].Type(), "new", fieldType)
+			newField := data.NewFieldFromFieldType(fieldType, 0)
+			newField.Name = df.Key()
+			df.Fields[idx] = newField
 		}
 		df.Fields[idx].Append(v)
 		return

--- a/pkg/plugin/framer_test.go
+++ b/pkg/plugin/framer_test.go
@@ -1,0 +1,509 @@
+package plugin
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+)
+
+func makeMsg(json string) *TimestampedMessage {
+	return &TimestampedMessage{
+		Timestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		Value:     []byte(json),
+	}
+}
+
+func findField(frame *data.Frame, name string) *data.Field {
+	for _, f := range frame.Fields {
+		if f.Name == name {
+			return f
+		}
+	}
+	return nil
+}
+
+// TestFramer_BasicFields verifies that a simple flat JSON message produces the
+// expected fields and that the timestamp field is populated.
+func TestFramer_BasicFields(t *testing.T) {
+	framer := NewFramer()
+	frame, err := framer.ToFrame(makeMsg(`{"name":"turbine1","power":42.5,"active":true}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, want := range []string{TIMESTAMP_NAME, "name", "power", "active"} {
+		if findField(frame, want) == nil {
+			t.Errorf("expected field %q to be present", want)
+		}
+	}
+
+	ts := findField(frame, TIMESTAMP_NAME)
+	if ts.Len() != 1 {
+		t.Fatalf("timestamp field: want len 1, got %d", ts.Len())
+	}
+
+	powerField := findField(frame, "power")
+	if powerField.Type() != data.FieldTypeNullableFloat64 {
+		t.Errorf("power field: want NullableFloat64, got %v", powerField.Type())
+	}
+	v, ok := powerField.ConcreteAt(0)
+	if !ok || v.(float64) != 42.5 {
+		t.Errorf("power field value: want 42.5, got %v (ok=%v)", v, ok)
+	}
+}
+
+// TestFramer_NestedObjectStoredAsJSON verifies that nested objects are stored
+// as a single JSON blob field rather than being flattened.
+func TestFramer_NestedObjectStoredAsJSON(t *testing.T) {
+	framer := NewFramer()
+	frame, err := framer.ToFrame(makeMsg(`{"source":{"id":"x","name":"y"},"value":1.0}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sourceField := findField(frame, "source")
+	if sourceField == nil {
+		t.Fatal("expected 'source' field to be present")
+	}
+	if sourceField.Type() != data.FieldTypeJSON {
+		t.Errorf("source field: want FieldTypeJSON, got %v", sourceField.Type())
+	}
+}
+
+// TestFramer_ConsecutiveMessages verifies that calling ToFrame twice in a row
+// produces correctly cleared frames. Note: because frames share field objects
+// with the framer, a frame's field data is only valid until the next ToFrame
+// call — here we check each frame immediately after it is produced.
+func TestFramer_ConsecutiveMessages(t *testing.T) {
+	framer := NewFramer()
+
+	frame1, err := framer.ToFrame(makeMsg(`{"value":1.0}`))
+	if err != nil {
+		t.Fatalf("first message error: %v", err)
+	}
+
+	// Inspect frame1 before the second ToFrame call mutates the shared fields.
+	f1 := findField(frame1, "value")
+	if f1 == nil {
+		t.Fatal("frame1: 'value' field missing")
+	}
+	if f1.Len() != 1 {
+		t.Errorf("frame1: want 1 row, got %d", f1.Len())
+	}
+	v1, ok := f1.ConcreteAt(0)
+	if !ok || v1.(float64) != 1.0 {
+		t.Errorf("frame1 value: want 1.0, got %v (ok=%v)", v1, ok)
+	}
+
+	frame2, err := framer.ToFrame(makeMsg(`{"value":2.0}`))
+	if err != nil {
+		t.Fatalf("second message error: %v", err)
+	}
+
+	f2 := findField(frame2, "value")
+	if f2 == nil {
+		t.Fatal("frame2: 'value' field missing")
+	}
+	if f2.Len() != 1 {
+		t.Errorf("frame2: want 1 row, got %d", f2.Len())
+	}
+	v2, ok := f2.ConcreteAt(0)
+	if !ok || v2.(float64) != 2.0 {
+		t.Errorf("frame2 value: want 2.0, got %v (ok=%v)", v2, ok)
+	}
+}
+
+// TestFramer_TypeMismatchReplacesField is the regression test for Bug #4.
+// Before the fix, AddValue silently dropped values when the Go type of a
+// field changed between messages. After the fix the field must be replaced
+// and the new value must be captured.
+func TestFramer_TypeMismatchReplacesField(t *testing.T) {
+	framer := NewFramer()
+
+	// First message: "status" is a number.
+	_, err := framer.ToFrame(makeMsg(`{"status":1.0}`))
+	if err != nil {
+		t.Fatalf("first message error: %v", err)
+	}
+
+	// Second message: "status" changed to a string.
+	frame2, err := framer.ToFrame(makeMsg(`{"status":"running"}`))
+	if err != nil {
+		t.Fatalf("second message error: %v", err)
+	}
+
+	f := findField(frame2, "status")
+	if f == nil {
+		t.Fatal("expected 'status' field in second frame")
+	}
+
+	// Field type must have been updated to NullableString.
+	if f.Type() != data.FieldTypeNullableString {
+		t.Errorf("after type change: want NullableString, got %v", f.Type())
+	}
+
+	// Value must be "running", not silently dropped.
+	if f.Len() != 1 {
+		t.Fatalf("want 1 value, got %d", f.Len())
+	}
+	v, ok := f.ConcreteAt(0)
+	if !ok {
+		t.Fatal("value is nil after type change")
+	}
+	if v.(string) != "running" {
+		t.Errorf("want %q, got %q", "running", v.(string))
+	}
+}
+
+// TestFramer_AllFieldsHaveSameLength verifies that ExtendFields pads fields
+// that are absent from a message so every frame row has uniform width.
+func TestFramer_AllFieldsHaveSameLength(t *testing.T) {
+	framer := NewFramer()
+
+	// First message introduces two fields.
+	framer.ToFrame(makeMsg(`{"a":1.0,"b":2.0}`))
+
+	// Second message only provides "a"; "b" must be padded to len 1.
+	frame, _ := framer.ToFrame(makeMsg(`{"a":3.0}`))
+
+	for _, f := range frame.Fields {
+		if f.Len() != 1 {
+			t.Errorf("field %q: want len 1, got %d", f.Name, f.Len())
+		}
+	}
+}
+
+// TestFramer_NullForKnownField is the regression test for the AddNil panic.
+// Before the fix, calling AddNil() on a field that had been cleared by the
+// ToFrame clearing loop would panic with "index out of range [0] with length 0"
+// because Set(0, nil) requires the underlying slice to have at least one element.
+// After the fix, AddNil() uses Append(nil) which is safe on a zero-length field.
+func TestFramer_NullForKnownField(t *testing.T) {
+	framer := NewFramer()
+
+	// First message: x has a concrete value so it is registered in FieldMap.
+	_, err := framer.ToFrame(makeMsg(`{"x":42.0}`))
+	if err != nil {
+		t.Fatalf("first message error: %v", err)
+	}
+
+	// Second message: x is null. After ToFrame clears the field to len=0,
+	// AddNil() must NOT panic when recording the null value.
+	frame, err := framer.ToFrame(makeMsg(`{"x":null}`))
+	if err != nil {
+		t.Fatalf("second message (null value): %v", err)
+	}
+
+	f := findField(frame, "x")
+	if f == nil {
+		t.Fatal("expected 'x' field to be present after null message")
+	}
+	if f.Len() != 1 {
+		t.Fatalf("want len 1, got %d", f.Len())
+	}
+	// Value at index 0 must be nil (the null that was recorded).
+	if _, ok := f.ConcreteAt(0); ok {
+		t.Error("want nil value at index 0, but got a concrete value")
+	}
+}
+
+// TestFramer_NullThenValue verifies that after a field records null, the next
+// message can restore it to a concrete value without errors.
+func TestFramer_NullThenValue(t *testing.T) {
+	framer := NewFramer()
+
+	framer.ToFrame(makeMsg(`{"x":42.0}`))
+	framer.ToFrame(makeMsg(`{"x":null}`))
+
+	frame, err := framer.ToFrame(makeMsg(`{"x":7.5}`))
+	if err != nil {
+		t.Fatalf("third message error: %v", err)
+	}
+
+	f := findField(frame, "x")
+	if f == nil {
+		t.Fatal("expected 'x' field after null-then-value sequence")
+	}
+	v, ok := f.ConcreteAt(0)
+	if !ok || v.(float64) != 7.5 {
+		t.Errorf("want 7.5, got %v (ok=%v)", v, ok)
+	}
+}
+
+// realLiveSignalsMessage is a minimal but structurally faithful sample of the
+// live-signals stream. It exercises:
+//   - "source": deeply nested object (stored as JSON blob)
+//   - "guid": top-level string field
+//   - "samples": nested object whose leaf values include integer 0, float 2.009,
+//     float 67.6, a string, nullable "unit" fields, and nullable "sortingPosition"
+//     fields (all stored together as a JSON blob)
+const realLiveSignalsMessage = `{"source":{"parkId":"triptiprow9","parkName":"Trip Tip Row 9","assetId":"us_chn_10","assetName":"CF22","assetType":"gam_g5.0mw-145","assetSortingName":"triptiprow9_010","oem":"AnemoLive","ipAddress":"192.168.20.101","timestampUtc":"2026-02-27T16:02:01.9966842Z","localTimestamp":"2026-02-27T11:02:01.9966842Z","eventType":"live-signals","displayName":"CF22"},"guid":"eb8307a0-9c05-48e9-91fb-7cc346f6856a","samples":{"PowerLimitComp":{"tag":"PowerLimitComp","value":0,"timestampUtc":"2026-02-27T16:02:01.9966842Z","name":"PowerLimitComp","unit":null,"assetName":"CF22","assetId":"us_chn_10","sortingPosition":null},"PropValveBSliderPosition":{"tag":"PropValveBSliderPosition","value":2.009,"timestampUtc":"2026-02-27T16:02:01.9966842Z","name":"PropValveBSliderPosition","unit":null,"assetName":"CF22","assetId":"us_chn_10","sortingPosition":null},"WSCS.GbxBrgHSGenTmp":{"tag":"WSCS.GbxBrgHSGenTmp","value":67.6,"timestampUtc":"2026-02-27T16:02:01.9966842Z","name":"Temp Gearbox Bearing","unit":"\u00b0C","assetName":"CF22","assetId":"us_chn_10","sortingPosition":"Tag_1"},"WSCS.TurSt":{"tag":"WSCS.TurSt","value":"TURBINE_PRODUCTION","timestampUtc":"2026-02-27T16:02:01.9966842Z","name":"Turbine State","unit":null,"assetName":"CF22","assetId":"us_chn_10","sortingPosition":null}}}`
+
+// TestFramer_RealLiveSignalsMessage tests the framer with a structurally
+// faithful representation of the live-signals RabbitMQ stream messages.
+// The message body has three top-level fields:
+//   - source: nested object -> stored as JSON blob
+//   - guid: string -> stored as NullableString
+//   - samples: nested object containing entries with integer (0), float (2.009),
+//     float (67.6), string values, and null unit / sortingPosition fields ->
+//     stored as a single JSON blob
+//
+// This test validates that the framer produces exactly these three top-level
+// fields plus the timestamp, with correct types, and does not panic on the
+// null values inside the samples blob.
+func TestFramer_RealLiveSignalsMessage(t *testing.T) {
+	framer := NewFramer()
+
+	frame, err := framer.ToFrame(makeMsg(realLiveSignalsMessage))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Must have exactly: timestamp, source, guid, samples.
+	wantFields := []string{TIMESTAMP_NAME, "source", "guid", "samples"}
+	for _, name := range wantFields {
+		if findField(frame, name) == nil {
+			t.Errorf("expected field %q to be present", name)
+		}
+	}
+
+	// Timestamp field must have exactly one row.
+	ts := findField(frame, TIMESTAMP_NAME)
+	if ts.Len() != 1 {
+		t.Errorf("timestamp: want len 1, got %d", ts.Len())
+	}
+
+	// source must be a JSON blob (nested object, not flattened).
+	src := findField(frame, "source")
+	if src.Type() != data.FieldTypeJSON {
+		t.Errorf("source: want FieldTypeJSON, got %v", src.Type())
+	}
+
+	// guid must be NullableString with the expected value.
+	guidField := findField(frame, "guid")
+	if guidField.Type() != data.FieldTypeNullableString {
+		t.Errorf("guid: want NullableString, got %v", guidField.Type())
+	}
+	guidVal, ok := guidField.ConcreteAt(0)
+	if !ok || guidVal.(string) != "eb8307a0-9c05-48e9-91fb-7cc346f6856a" {
+		t.Errorf("guid value: want %q, got %v (ok=%v)", "eb8307a0-9c05-48e9-91fb-7cc346f6856a", guidVal, ok)
+	}
+
+	// samples must be a JSON blob (nested object containing all sample entries
+	// including those with null unit and null sortingPosition).
+	samplesField := findField(frame, "samples")
+	if samplesField.Type() != data.FieldTypeJSON {
+		t.Errorf("samples: want FieldTypeJSON, got %v", samplesField.Type())
+	}
+
+	// All fields must have exactly one row.
+	for _, f := range frame.Fields {
+		if f.Len() != 1 {
+			t.Errorf("field %q: want len 1, got %d", f.Name, f.Len())
+		}
+	}
+}
+
+// TestFramer_RealLiveSignalsConsecutiveMessages verifies that two consecutive
+// real-format messages are processed correctly: fields are cleared between
+// messages, the second frame has the right data, and field counts match.
+func TestFramer_RealLiveSignalsConsecutiveMessages(t *testing.T) {
+	framer := NewFramer()
+
+	// Second message uses the same structure but a different guid.
+	msg2 := `{"source":{"parkId":"triptiprow9","parkName":"Trip Tip Row 9","assetId":"us_chn_10","assetName":"CF22","assetType":"gam_g5.0mw-145","assetSortingName":"triptiprow9_010","oem":"AnemoLive","ipAddress":"192.168.20.101","timestampUtc":"2026-02-27T16:03:00Z","localTimestamp":"2026-02-27T11:03:00Z","eventType":"live-signals","displayName":"CF22"},"guid":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","samples":{"PowerLimitComp":{"tag":"PowerLimitComp","value":0,"timestampUtc":"2026-02-27T16:03:00Z","name":"PowerLimitComp","unit":null,"assetName":"CF22","assetId":"us_chn_10","sortingPosition":null},"PropValveBSliderPosition":{"tag":"PropValveBSliderPosition","value":2.009,"timestampUtc":"2026-02-27T16:03:00Z","name":"PropValveBSliderPosition","unit":null,"assetName":"CF22","assetId":"us_chn_10","sortingPosition":null}}}`
+
+	frame1, err := framer.ToFrame(makeMsg(realLiveSignalsMessage))
+	if err != nil {
+		t.Fatalf("first message error: %v", err)
+	}
+
+	// Validate frame1 guid before the second call mutates shared fields.
+	g1 := findField(frame1, "guid")
+	if g1 == nil {
+		t.Fatal("frame1: 'guid' field missing")
+	}
+	v1, ok := g1.ConcreteAt(0)
+	if !ok || v1.(string) != "eb8307a0-9c05-48e9-91fb-7cc346f6856a" {
+		t.Errorf("frame1 guid: want original uuid, got %v (ok=%v)", v1, ok)
+	}
+
+	frame2, err := framer.ToFrame(makeMsg(msg2))
+	if err != nil {
+		t.Fatalf("second message error: %v", err)
+	}
+
+	// All fields in frame2 must have exactly one row.
+	for _, f := range frame2.Fields {
+		if f.Len() != 1 {
+			t.Errorf("frame2 field %q: want len 1, got %d", f.Name, f.Len())
+		}
+	}
+
+	// guid in frame2 must reflect the second message's value.
+	g2 := findField(frame2, "guid")
+	if g2 == nil {
+		t.Fatal("frame2: 'guid' field missing")
+	}
+	v2, ok := g2.ConcreteAt(0)
+	if !ok || v2.(string) != "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" {
+		t.Errorf("frame2 guid: want new uuid, got %v (ok=%v)", v2, ok)
+	}
+}
+
+// TestFramer_NullableUnitAndSortingPosition verifies that samples containing
+// null "unit" and null "sortingPosition" fields (as seen in the real
+// live-signals stream) are stored correctly as part of the JSON blob.
+// This is a documentation test: the framer does not parse inside the samples
+// blob, so the nulls are simply preserved in the raw JSON.
+func TestFramer_NullableUnitAndSortingPosition(t *testing.T) {
+	framer := NewFramer()
+
+	// Message whose samples contain entries with null unit and sortingPosition
+	// (mirrors the real PowerLimitComp sample) as well as one with non-null
+	// unit and sortingPosition (mirrors WSCS.GbxBrgHSGenTmp).
+	const msg = `{"source":{"parkId":"triptiprow9"},"guid":"test-guid","samples":{"PowerLimitComp":{"tag":"PowerLimitComp","value":0,"timestampUtc":"2026-02-27T16:02:01Z","name":"PowerLimitComp","unit":null,"assetName":"CF22","assetId":"us_chn_10","sortingPosition":null},"WSCS.GbxBrgHSGenTmp":{"tag":"WSCS.GbxBrgHSGenTmp","value":67.6,"timestampUtc":"2026-02-27T16:02:01Z","name":"Temp Gearbox Bearing","unit":"\u00b0C","assetName":"CF22","assetId":"us_chn_10","sortingPosition":"Tag_1"}}}`
+
+	frame, err := framer.ToFrame(makeMsg(msg))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The samples blob must be present and non-empty.
+	samplesField := findField(frame, "samples")
+	if samplesField == nil {
+		t.Fatal("'samples' field missing")
+	}
+	if samplesField.Type() != data.FieldTypeJSON {
+		t.Errorf("samples: want FieldTypeJSON, got %v", samplesField.Type())
+	}
+	samplesVal, ok := samplesField.ConcreteAt(0)
+	if !ok {
+		t.Fatal("samples value is nil")
+	}
+	// The blob must contain the null unit value for PowerLimitComp.
+	// The framer stores JSON blobs as json.RawMessage.
+	blob := string(samplesVal.(json.RawMessage))
+	if len(blob) == 0 {
+		t.Error("samples blob is empty")
+	}
+}
+
+// TestFramer_NullForJSONField is the regression test for the alarm-stream panic.
+// When a field is first seen as a JSON blob (FieldTypeJSON) and a subsequent
+// message sends null for that field, AddNil must NOT panic with
+// "interface conversion: interface {} is nil, not json.RawMessage".
+// FieldTypeJSON is non-nullable so the nil must be skipped and ExtendFields
+// pads with the zero value instead.
+func TestFramer_NullForJSONField(t *testing.T) {
+	framer := NewFramer()
+
+	// First message: "payload" is an object → stored as FieldTypeJSON blob.
+	_, err := framer.ToFrame(makeMsg(`{"payload":{"key":"value","count":1}}`))
+	if err != nil {
+		t.Fatalf("first message error: %v", err)
+	}
+
+	// Second message: "payload" is null. Must NOT panic.
+	frame, err := framer.ToFrame(makeMsg(`{"payload":null}`))
+	if err != nil {
+		t.Fatalf("second message (null JSON field) error: %v", err)
+	}
+
+	f := findField(frame, "payload")
+	if f == nil {
+		t.Fatal("expected 'payload' field to be present")
+	}
+	if f.Len() != 1 {
+		t.Fatalf("want len 1, got %d", f.Len())
+	}
+}
+
+// TestFramer_NullForArrayField verifies the same non-nullable nil behaviour for
+// FieldTypeJSON fields that were originally populated from a JSON array.
+func TestFramer_NullForArrayField(t *testing.T) {
+	framer := NewFramer()
+
+	// First message: "tags" is an array → FieldTypeJSON.
+	_, err := framer.ToFrame(makeMsg(`{"tags":["alarm","critical"]}`))
+	if err != nil {
+		t.Fatalf("first message error: %v", err)
+	}
+
+	// Second message: "tags" is null. Must NOT panic.
+	frame, err := framer.ToFrame(makeMsg(`{"tags":null}`))
+	if err != nil {
+		t.Fatalf("second message (null array field) error: %v", err)
+	}
+
+	f := findField(frame, "tags")
+	if f == nil {
+		t.Fatal("expected 'tags' field to be present")
+	}
+	if f.Len() != 1 {
+		t.Fatalf("want len 1, got %d", f.Len())
+	}
+}
+
+// TestFramer_IntegerZeroValue verifies that a JSON integer value of 0 is
+// correctly stored as float64(0) in the framer (jsoniter reads all JSON numbers
+// as float64 when using ReadFloat64).
+func TestFramer_IntegerZeroValue(t *testing.T) {
+	framer := NewFramer()
+
+	// 'count' has integer value 0 — this is the PowerLimitComp pattern.
+	frame, err := framer.ToFrame(makeMsg(`{"count":0}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	f := findField(frame, "count")
+	if f == nil {
+		t.Fatal("'count' field missing")
+	}
+	if f.Type() != data.FieldTypeNullableFloat64 {
+		t.Errorf("count: want NullableFloat64, got %v", f.Type())
+	}
+	v, ok := f.ConcreteAt(0)
+	if !ok || v.(float64) != 0 {
+		t.Errorf("count value: want 0, got %v (ok=%v)", v, ok)
+	}
+}
+
+// TestFramer_FloatValues verifies that float values 2.009 and 67.6 (representative
+// of PropValveBSliderPosition and WSCS.GbxBrgHSGenTmp from the real stream) are
+// stored with full precision.
+func TestFramer_FloatValues(t *testing.T) {
+	framer := NewFramer()
+
+	frame, err := framer.ToFrame(makeMsg(`{"valve":2.009,"temp":67.6}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	valve := findField(frame, "valve")
+	if valve == nil {
+		t.Fatal("'valve' field missing")
+	}
+	v, ok := valve.ConcreteAt(0)
+	if !ok {
+		t.Fatal("valve value is nil")
+	}
+	if v.(float64) != 2.009 {
+		t.Errorf("valve: want 2.009, got %v", v)
+	}
+
+	temp := findField(frame, "temp")
+	if temp == nil {
+		t.Fatal("'temp' field missing")
+	}
+	v2, ok := temp.ConcreteAt(0)
+	if !ok {
+		t.Fatal("temp value is nil")
+	}
+	if v2.(float64) != 67.6 {
+		t.Errorf("temp: want 67.6, got %v", v2)
+	}
+}

--- a/pkg/plugin/stream.go
+++ b/pkg/plugin/stream.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
@@ -16,29 +17,82 @@ func (ds *RabbitMQDatasource) RunStream(ctx context.Context, req *backend.RunStr
 	log.DefaultLogger.Info("Called RunStream method", "RabbitMQ Stream", ds.Client.ToString())
 
 	framer := NewFramer()
+	msgCh := make(chan []byte, 256)
+
+	// Sender goroutine: decouples frame building and SendFrame from the RabbitMQ
+	// consumer callback, preventing back-pressure from blocking message delivery.
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case raw, ok := <-msgCh:
+				if !ok {
+					return
+				}
+				log.DefaultLogger.Debug("Received message", "message", string(raw))
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							log.DefaultLogger.Error("Panic processing message, skipping",
+								"recover", fmt.Sprintf("%v", r),
+								"RabbitMQ Stream", ds.Client.ToString(),
+							)
+						}
+					}()
+					timestamped_msg := NewTimestampedMessage(raw)
+					frame, err := framer.ToFrame(timestamped_msg)
+					if err != nil {
+						log.DefaultLogger.Error("Error creating frame from message", "error", err)
+						return
+					}
+					if err = sender.SendFrame(frame, data.IncludeAll); err != nil {
+						log.DefaultLogger.Error("Error sending frame", "error", err)
+					}
+				}()
+			}
+		}
+	}()
 
 	handleMessages := func(consumerContext stream.ConsumerContext, message *amqp.Message) {
-		log.DefaultLogger.Debug("Received message", "message", string(message.Data[0]))
-
-		timestamped_msg := NewTimestampedMessage(message.Data[0])
-		frame, err := framer.ToFrame(timestamped_msg)
-		if err != nil {
-			log.DefaultLogger.Error("Error creating frame from message", "message", string(message.Data[0]), "error", err)
+		var raw []byte
+		if len(message.Data) > 0 {
+			// AMQP 1.0 Data section (most stream-native publishers).
+			raw = make([]byte, len(message.Data[0]))
+			copy(raw, message.Data[0])
+		} else if v, ok := message.Value.([]byte); ok {
+			// AMQP Value section carrying a binary payload (common when messages
+			// are published via an AMQP 0-9-1 client that is routed into a stream).
+			raw = make([]byte, len(v))
+			copy(raw, v)
+		} else if message.Value != nil {
+			log.DefaultLogger.Warn("Received message with unsupported Value type, skipping",
+				"type", fmt.Sprintf("%T", message.Value),
+				"RabbitMQ Stream", ds.Client.ToString(),
+			)
+			return
+		} else {
+			log.DefaultLogger.Warn("Received message with no Data and no Value payload, skipping",
+				"RabbitMQ Stream", ds.Client.ToString(),
+			)
 			return
 		}
-
 		select {
-		case <-ctx.Done():
-			log.DefaultLogger.Debug("Error sending frame because context canceled", "frame", frame, "error", err)
+		case msgCh <- raw:
 		default:
-			err = sender.SendFrame(frame, data.IncludeAll)
-			if err != nil {
-				log.DefaultLogger.Error("Error sending frame", "frame", frame, "error", err)
-			}
+			log.DefaultLogger.Warn("Message dropped, send buffer full", "RabbitMQ Stream", ds.Client.ToString())
 		}
 	}
 
 	for {
+		select {
+		case <-ctx.Done():
+			log.DefaultLogger.Debug("Stopped streaming - Context Canceled", "RabbitMQ Stream", ds.Client.ToString())
+			ds.Client.Dispose()
+			return nil
+		default:
+		}
+
 		log.DefaultLogger.Debug("Creating new consumer", "RabbitMQ Stream", ds.Client.ToString())
 		if !ds.Client.IsConnected() {
 			_, err := ds.Client.Connect()
@@ -50,6 +104,11 @@ func (ds *RabbitMQDatasource) RunStream(ctx context.Context, req *backend.RunStr
 		if errors.Is(err, rabbitmqclient.ErrConsumerWasAlreadyCreated) {
 			return nil
 		}
+		if err != nil {
+			log.DefaultLogger.Error("Failed to create consumer, stream will be re-established by Grafana", "RabbitMQ Stream", ds.Client.ToString(), "error", err)
+			ds.Client.Dispose()
+			return err
+		}
 
 		select {
 		case <-ctx.Done():
@@ -58,10 +117,11 @@ func (ds *RabbitMQDatasource) RunStream(ctx context.Context, req *backend.RunStr
 			return nil
 		case <-consumer.NotifyClose():
 			log.DefaultLogger.Info(
-				"Something went wrong with the RabbitMQ. Trying to reconnect...",
+				"RabbitMQ consumer closed, stream will be re-established by Grafana",
 				"RabbitMQ Stream", ds.Client.ToString(),
 			)
-			ds.Client.Reconnect()
+			ds.Client.Dispose()
+			return fmt.Errorf("RabbitMQ consumer closed unexpectedly")
 		}
 	}
 }

--- a/pkg/plugin/stream_test.go
+++ b/pkg/plugin/stream_test.go
@@ -1,0 +1,121 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/maormil/rabbitmq-datasource/pkg/rabbitmqclient"
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
+)
+
+// mockClient implements rabbitmqclient.Client for testing.
+type mockClient struct {
+	connected bool
+	consumeFn func(stream.MessagesHandler) (*stream.Consumer, error)
+	disposed  bool
+}
+
+func (m *mockClient) IsConnected() bool { return m.connected }
+func (m *mockClient) Connect() (rabbitmqclient.Client, error) {
+	m.connected = true
+	return m, nil
+}
+func (m *mockClient) Reconnect() rabbitmqclient.Client {
+	m.connected = true
+	return m
+}
+func (m *mockClient) Consume(handler stream.MessagesHandler) (*stream.Consumer, error) {
+	return m.consumeFn(handler)
+}
+func (m *mockClient) Dispose() {
+	m.connected = false
+	m.disposed = true
+}
+func (m *mockClient) ToString() string { return "mock" }
+
+// TestRunStream_ConsumeErrorReturnsErrorAndDisposesClient verifies that when
+// Consume() returns an error (other than ErrConsumerWasAlreadyCreated),
+// RunStream returns that error and calls Dispose() so Grafana can manage the
+// reconnection with its own exponential-backoff retry.
+func TestRunStream_ConsumeErrorReturnsErrorAndDisposesClient(t *testing.T) {
+	consumeErr := errors.New("stream does not exist")
+	mock := &mockClient{
+		connected: true,
+		consumeFn: func(_ stream.MessagesHandler) (*stream.Consumer, error) {
+			return nil, consumeErr
+		},
+	}
+
+	ds := NewRabbitMQDatasource(mock)
+	err := ds.RunStream(context.Background(), &backend.RunStreamRequest{}, &backend.StreamSender{})
+	if err == nil {
+		t.Error("expected an error but got nil")
+	}
+	if !errors.Is(err, consumeErr) {
+		t.Errorf("unexpected error: want %v, got %v", consumeErr, err)
+	}
+	if !mock.disposed {
+		t.Error("Dispose() was not called after consume error")
+	}
+}
+
+// TestRunStream_ContextCancellationStopsLoop verifies that cancelling the
+// context causes RunStream to exit cleanly (returning nil) when waiting on
+// a consumer's NotifyClose channel.
+func TestRunStream_ContextCancellationStopsLoop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// consumeFn returns ErrConsumerWasAlreadyCreated after context is cancelled
+	// so that RunStream exits cleanly on the next iteration.
+	callCount := 0
+	mock := &mockClient{
+		connected: false, // forces Connect() path
+		consumeFn: func(_ stream.MessagesHandler) (*stream.Consumer, error) {
+			callCount++
+			// Return error so RunStream returns immediately and lets Grafana retry.
+			return nil, errors.New("always fails")
+		},
+	}
+
+	ds := NewRabbitMQDatasource(mock)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- ds.RunStream(ctx, &backend.RunStreamRequest{}, &backend.StreamSender{})
+	}()
+
+	// Give one cycle to run (Connect succeeds, Consume fails, RunStream returns error).
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		// With the new behavior, RunStream returns an error (not nil) when Consume fails.
+		// The context cancellation test is about ensuring the loop doesn't hang.
+		// Either nil (if ctx cancel was caught) or the consume error is acceptable.
+		_ = err // both are valid outcomes; no hang is the key assertion
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunStream did not exit in time")
+	}
+}
+
+// TestRunStream_ErrConsumerAlreadyCreatedExitsCleanly verifies that the
+// ErrConsumerWasAlreadyCreated sentinel causes RunStream to return nil,
+// indicating the stream is already being handled elsewhere.
+func TestRunStream_ErrConsumerAlreadyCreatedExitsCleanly(t *testing.T) {
+	mock := &mockClient{
+		connected: true,
+		consumeFn: func(_ stream.MessagesHandler) (*stream.Consumer, error) {
+			return nil, rabbitmqclient.ErrConsumerWasAlreadyCreated
+		},
+	}
+
+	ds := NewRabbitMQDatasource(mock)
+	err := ds.RunStream(context.Background(), &backend.RunStreamRequest{}, &backend.StreamSender{})
+	if err != nil {
+		t.Errorf("unexpected error for ErrConsumerWasAlreadyCreated: %v", err)
+	}
+}

--- a/pkg/rabbitmqclient/client.go
+++ b/pkg/rabbitmqclient/client.go
@@ -169,6 +169,11 @@ func (client *RabbitMQStreamClient) Connect() (Client, error) {
 
 	log.DefaultLogger.Debug("Trying to set the RabbitMQ objects...")
 	client.SetStream()
+	// Reset slices before re-populating so that repeated Connect() calls (e.g. on
+	// reconnect) do not accumulate duplicate entries and cause redundant AMQP
+	// declare/bind operations.
+	client.Exchanges = nil
+	client.Bindings = nil
 	client.SetExchanges()
 	client.SetBindings()
 	log.DefaultLogger.Debug("Successfully set the RabbitMQ objects!")

--- a/pkg/rabbitmqclient/stream.go
+++ b/pkg/rabbitmqclient/stream.go
@@ -64,9 +64,12 @@ func (streamOptions *StreamOptions) Consume(env *stream.Environment, messagesHan
 		streamOptions.StreamName,
 		messagesHandler,
 		stream.NewConsumerOptions().
-			SetConsumerName(streamOptions.getConsumerName()). // Set a consumer name
-			SetOffset(streamOptions.getOffsetSettings()).     // Start consuming from the beginning
-			SetCRCCheck(streamOptions.Crc),                   // Disabled CRC control increase the performances
+			SetConsumerName(streamOptions.getConsumerName()).
+			SetOffset(streamOptions.getOffsetSettings()).
+			SetCRCCheck(streamOptions.Crc).
+			SetAutoCommit(stream.NewAutoCommitStrategy().
+				SetCountBeforeStorage(50).
+				SetFlushInterval(5*time.Second)),
 	)
 	if err != nil {
 		return nil, failOnError(err, fmt.Sprintf("Failed to create the consumer: %s", streamOptions.ConsumerName))
@@ -95,10 +98,14 @@ func (streamOptions *StreamOptions) getConsumerName() string {
 func (streamOptions *StreamOptions) closeConsumer() error {
 	if streamOptions.Consumer == nil {
 		return nil
-	} else if err := streamOptions.Consumer.Close(); err != nil {
-		return failOnError(err, fmt.Sprintf("Failed to close the consumer: %s", streamOptions.ConsumerName))
-	} else {
-		streamOptions.Consumer = nil
-		return nil
 	}
+	err := streamOptions.Consumer.Close()
+	// Always clear the pointer so Reconnect() can make progress even if Close()
+	// returns AlreadyClosed or another error.  Leaving it non-nil causes
+	// DisposeStream → closeConsumer to loop infinitely inside Reconnect().
+	streamOptions.Consumer = nil
+	if err != nil {
+		return failOnError(err, fmt.Sprintf("Failed to close the consumer: %s", streamOptions.ConsumerName))
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

This PR fixes a set of bugs that caused panics, silent data loss, and
unreliable reconnection behaviour in the streaming path.

### Framer fixes (`pkg/plugin/framer.go`)

**`AddNil()` panic on FieldTypeJSON fields**
The original code called `Set(0, nil)` on a field that had been cleared
to length 0 by the preceding frame-reset loop, causing an index-out-of-range
panic. It also called `Append(nil)` unconditionally, which panics for
non-nullable types such as `FieldTypeJSON` because the SDK performs an
internal type assertion to `json.RawMessage` that fails for an untyped nil.
Fix: use `Append(nil)` only when `field.Type().Nullable()` is true; for
non-nullable fields skip the append and let `ExtendFields` pad with the
zero value.

**`AddValue()` silently dropped values on type change**
When the inferred Go type of a JSON field changed between messages (e.g.
a field that was previously a number becomes a string), `AddValue()`
logged a debug line and returned without recording the new value. Fix:
replace the field with a fresh one of the correct type so the value is
captured.

### Stream reliability (`pkg/plugin/stream.go`)

* **Decoupled sender goroutine** — frame building and `SendFrame` now run
  in a separate goroutine fed by a 256-entry buffered channel, preventing
  a slow or blocked `SendFrame` call from stalling message delivery in the
  RabbitMQ consumer callback.
* **Panic recovery** — the sender goroutine wraps each message in a
  `recover()` so a single bad message cannot crash the whole stream.
* **AMQP Value-section support** — messages published via an AMQP 0-9-1
  client that are routed into a stream arrive with their payload in
  `message.Value` (a `[]byte`) rather than `message.Data`. These are now
  handled correctly instead of being silently dropped.
* **Grafana-managed reconnection** — instead of calling `Reconnect()`
  internally (which had an infinite-loop bug, see below), `RunStream` now
  calls `Dispose()` and returns an error, letting Grafana's built-in
  exponential-backoff retry own the reconnection lifecycle.

### RabbitMQ client fixes

**`pkg/rabbitmqclient/client.go` — duplicate exchanges/bindings on reconnect**
`SetExchanges()` and `SetBindings()` appended to existing slices, so
every reconnect doubled the configured resources. The slices are now
reset to `nil` before re-populating.

**`pkg/rabbitmqclient/stream.go` — infinite loop in `closeConsumer()`**
The original code only cleared `Consumer = nil` in the success branch of
the `Close()` call. If `Close()` returned `AlreadyClosed`, the pointer
remained non-nil and `DisposeStream → closeConsumer` looped forever inside
`Reconnect()`. Fix: always clear the pointer before inspecting the error.

**Offset auto-commit** — added `SetAutoCommit` (every 50 messages or 5 s)
so the consumer's offset is durably persisted and a restart does not
re-deliver already-processed messages.

## Test plan

- [ ] `go test ./pkg/plugin/...` passes — 14 new framer tests and 3 new
  stream tests covering all fixed code paths, including regression tests
  for each panic scenario.
- [ ] Manual smoke-test: connect to a RabbitMQ stream with mixed-type
  fields and verify no panics appear in Grafana logs.
- [ ] Manual smoke-test: kill the RabbitMQ broker while Grafana is
  streaming and verify the panel reconnects automatically via Grafana's
  retry mechanism.
